### PR TITLE
Added support for VMA

### DIFF
--- a/VulkanLaunchpad.cpp
+++ b/VulkanLaunchpad.cpp
@@ -4,9 +4,15 @@
  */
 #include "VulkanLaunchpad.h"
 #include <vulkan/vulkan.hpp>
+#define USE_VMA
+#ifdef USE_VMA
+#define VMA_IMPLEMENTATION
+#include <vma/vk_mem_alloc.h>
+#endif
 #include <unordered_map>
 #include <map>
 #include <deque>
+#include <variant>
 #define TINYOBJLOADER_IMPLEMENTATION
 #include <tinyobjloader/tiny_obj_loader.h>
 //#define USE_SHADERC
@@ -47,7 +53,11 @@ vk::DispatchLoaderStatic mDispatchLoader = {};
 vk::Queue mQueue                         = {};
 VklSwapchainConfig mSwapchainConfig      = {};
 std::vector<std::vector<vk::ClearValue>> mClearValues;
-                                 
+
+#ifdef USE_VMA
+VmaAllocator mVmaAllocator               = {};
+#endif
+
 bool mFrameworkInitialized = false;
 
 vk::DispatchLoaderDynamic mDynamicDispatch;
@@ -72,9 +82,15 @@ int mFrameInFlightIndex;
 uint32_t mCurrentSwapChainImageIndex;
 
 vk::UniqueCommandPool mCommandPool;
+#ifdef USE_VMA
+std::unordered_map<VkBuffer, std::variant<vk::UniqueDeviceMemory, VmaAllocation>> mHostCoherentBuffersWithBackingMemory;
+std::unordered_map<VkBuffer, std::variant<vk::UniqueDeviceMemory, VmaAllocation>> mDeviceLocalBuffersWithBackingMemory;
+std::unordered_map<VkImage, std::variant<vk::UniqueDeviceMemory, VmaAllocation>> mImagesWithBackingMemory;
+#else
 std::unordered_map<VkBuffer, vk::UniqueDeviceMemory> mHostCoherentBuffersWithBackingMemory;
 std::unordered_map<VkBuffer, vk::UniqueDeviceMemory> mDeviceLocalBuffersWithBackingMemory;
 std::unordered_map<VkImage, vk::UniqueDeviceMemory> mImagesWithBackingMemory;
+#endif
 std::deque<vk::UniqueCommandBuffer> mSingleUseCommandBuffers;
 
 std::unordered_map<VkPipeline, std::tuple<vk::UniqueDescriptorSetLayout, vk::UniquePipelineLayout>> mPipelineLayouts;
@@ -698,7 +714,7 @@ VkDeviceMemory vklAllocateMemoryForGivenRequirements(VkDeviceSize bufferSize, Vk
 		return memory;
 	}
 	else {
-      VKL_EXIT_WITH_ERROR(std::string("Error allocating memory of size [") + std::to_string(bufferSize) + "] and requirements[" + std::to_string(memoryRequirements.alignment) + ", " + std::to_string(memoryRequirements.memoryTypeBits) + ", " + std::to_string(memoryRequirements.size) + "]\n    Error Code: " + to_string(returnCode));
+    	VKL_EXIT_WITH_ERROR(std::string("Error allocating memory of size [") + std::to_string(bufferSize) + "] and requirements[" + std::to_string(memoryRequirements.alignment) + ", " + std::to_string(memoryRequirements.memoryTypeBits) + ", " + std::to_string(memoryRequirements.size) + "]\n    Error Code: " + to_string(returnCode));
 	}
 }
 
@@ -718,6 +734,20 @@ VkBuffer vklCreateHostCoherentBufferWithBackingMemory(VkDeviceSize buffer_size, 
 	auto createInfo = vk::BufferCreateInfo{}
 		.setSize(static_cast<vk::DeviceSize>(buffer_size))
 		.setUsage(vk::BufferUsageFlags{ buffer_usage });
+
+#ifdef USE_VMA
+	if (mVmaAllocator) {
+		VmaAllocationCreateInfo vmaBufferCreateInfo = {};
+		vmaBufferCreateInfo.usage = VMA_MEMORY_USAGE_UNKNOWN;
+		vmaBufferCreateInfo.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+		VkBuffer bufferFromVma;
+		VmaAllocation vmaAllocation;
+		vmaCreateBuffer(mVmaAllocator, &static_cast<const VkBufferCreateInfo&>(createInfo), &vmaBufferCreateInfo, &bufferFromVma, &vmaAllocation, nullptr);
+		mHostCoherentBuffersWithBackingMemory[bufferFromVma] = std::move(vmaAllocation);
+		return bufferFromVma;
+	}
+#endif
+
 	auto buffer = mDevice.createBuffer(createInfo);
 
 	// Allocate the memory (we want host-coherent memory):
@@ -743,6 +773,20 @@ VkBuffer vklCreateDeviceLocalBufferWithBackingMemory(VkDeviceSize buffer_size, V
 	auto createInfo = vk::BufferCreateInfo{}
 		.setSize(static_cast<vk::DeviceSize>(buffer_size))
 		.setUsage(vk::BufferUsageFlags{ buffer_usage });
+
+#ifdef USE_VMA
+	if (mVmaAllocator) {
+		VmaAllocationCreateInfo vmaBufferCreateInfo = {};
+		vmaBufferCreateInfo.usage = VMA_MEMORY_USAGE_UNKNOWN;
+		vmaBufferCreateInfo.requiredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+		VkBuffer bufferFromVma;
+		VmaAllocation vmaAllocation;
+		vmaCreateBuffer(mVmaAllocator, &static_cast<const VkBufferCreateInfo&>(createInfo), &vmaBufferCreateInfo, &bufferFromVma, &vmaAllocation, nullptr);
+		mDeviceLocalBuffersWithBackingMemory[bufferFromVma] = std::move(vmaAllocation);
+		return bufferFromVma;
+	}
+#endif
+
 	auto buffer = mDevice.createBuffer(createInfo);
 
 	// Allocate the memory (we want device-local memory):
@@ -767,15 +811,24 @@ void vklDestroyHostCoherentBufferAndItsBackingMemory(VkBuffer buffer)
 		VKL_EXIT_WITH_ERROR("Invalid buffer handle passed to vklDestroyHostCoherentBufferAndItsBackingMemory(...)");
 	}
 
+	bool resourceDestroyed = false;
 	auto search = mHostCoherentBuffersWithBackingMemory.find(buffer);
 	if (mHostCoherentBuffersWithBackingMemory.end() != search) {
+#ifdef USE_VMA
+		if (std::holds_alternative<VmaAllocation>(search->second)) {
+			vmaDestroyBuffer(mVmaAllocator, buffer, std::get<VmaAllocation>(search->second));
+			resourceDestroyed = true;
+		}
+#endif
 		mHostCoherentBuffersWithBackingMemory.erase(search);
 	}
 	else {
 		VKL_WARNING("VkDeviceMemory for the given VkBuffer not found. Are you sure that you have created this buffer with vklCreateHostCoherentBufferWithBackingMemory(...)? Are you sure that you haven't already destroyed this VkBuffer?");
 	}
 
-	mDevice.destroy(vk::Buffer{ buffer });
+	if (!resourceDestroyed) {
+		mDevice.destroy(vk::Buffer{ buffer });
+	}
 }
 
 void vklDestroyDeviceLocalBufferAndItsBackingMemory(VkBuffer buffer)
@@ -787,15 +840,24 @@ void vklDestroyDeviceLocalBufferAndItsBackingMemory(VkBuffer buffer)
 		VKL_EXIT_WITH_ERROR("Invalid buffer handle passed to vklDestroyDeviceLocalBufferAndItsBackingMemory(...)");
 	}
 
+	bool resourceDestroyed = false;
 	auto search = mDeviceLocalBuffersWithBackingMemory.find(buffer);
 	if (mDeviceLocalBuffersWithBackingMemory.end() != search) {
+#ifdef USE_VMA
+		if (std::holds_alternative<VmaAllocation>(search->second)) {
+			vmaDestroyBuffer(mVmaAllocator, buffer, std::get<VmaAllocation>(search->second));
+			resourceDestroyed = true;
+		}
+#endif
 		mDeviceLocalBuffersWithBackingMemory.erase(search);
 	}
 	else {
 		VKL_WARNING("VkDeviceMemory for the given VkBuffer not found. Are you sure that you have created this buffer with vklCreateDeviceLocalBufferWithBackingMemory(...)? Are you sure that you haven't already destroyed this VkBuffer?");
 	}
 
-	mDevice.destroy(vk::Buffer{ buffer });
+	if (!resourceDestroyed) {
+		mDevice.destroy(vk::Buffer{ buffer });
+	}
 }
 
 void vklCopyDataIntoHostCoherentBuffer(VkBuffer buffer, const void* data_pointer, size_t data_size_in_bytes)
@@ -817,10 +879,26 @@ void vklCopyDataIntoHostCoherentBuffer(VkBuffer buffer, size_t buffer_offset_in_
 		VKL_EXIT_WITH_ERROR("Couldn't find backing memory for the given VkBuffer => Can't copy data. Have you created the buffer via vklCreateHostCoherentBufferWithBackingMemory(...)?");
 	}
 
+#ifdef USE_VMA
+	if (std::holds_alternative<VmaAllocation>(search->second)) {
+		void* mappedData;
+		auto result = vmaMapMemory(mVmaAllocator, std::get<VmaAllocation>(search->second), &mappedData);
+		assert(result >= 0);
+		memcpy(mappedData, data_pointer, data_size_in_bytes);
+		vmaUnmapMemory(mVmaAllocator, std::get<VmaAllocation>(search->second));
+	}
+	else {
+		uint8_t* mappedMemory = static_cast<uint8_t*>(mDevice.mapMemory(std::get<vk::UniqueDeviceMemory>(search->second).get(), 0, static_cast<vk::DeviceSize>(data_size_in_bytes)));
+		mappedMemory += buffer_offset_in_bytes;
+		memcpy(mappedMemory, data_pointer, data_size_in_bytes);
+		mDevice.unmapMemory(std::get<vk::UniqueDeviceMemory>(search->second).get());
+	}
+#else
 	uint8_t* mappedMemory = static_cast<uint8_t*>(mDevice.mapMemory(search->second.get(), 0, static_cast<vk::DeviceSize>(data_size_in_bytes)));
 	mappedMemory += buffer_offset_in_bytes;
 	memcpy(mappedMemory, data_pointer, data_size_in_bytes);
 	mDevice.unmapMemory(search->second.get());
+#endif
 }
 
 /*!
@@ -954,6 +1032,20 @@ bool vklInitFramework(VkInstance vk_instance, VkSurfaceKHR vk_surface, VkPhysica
 		vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation,
 		DebugUtilsMessengerCallback, nullptr
 	}, nullptr, mDynamicDispatch);
+
+#ifdef USE_VMA
+	VmaAllocatorCreateInfo vmaCreateInfo = {};
+	vmaCreateInfo.instance = vk_instance;
+	vmaCreateInfo.physicalDevice = vk_physical_device;
+	vmaCreateInfo.device = vk_device;
+	auto vmaResult = vmaCreateAllocator(&vmaCreateInfo, &mVmaAllocator);
+	if (VK_SUCCESS != vmaResult) {
+		VKL_EXIT_WITH_ERROR("Failed to initialize VMA. You might want to try undefining USE_VMA.");
+	}
+	// TODO: you should inform the library which Vulkan version do you use by setting VmaAllocatorCreateInfo::vulkanApiVersion
+	// TODO: which extensions did you enable by setting VmaAllocatorCreateInfo::flags (like VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT for VK_KHR_buffer_device_address)
+	// Otherwise, VMA would use only features of Vulkan 1.0 core with no extensions.
+#endif
 
 	// See if we can get some information about the surface:
 	auto surfaceCapabilities = mPhysicalDevice.getSurfaceCapabilitiesKHR(mSurface);
@@ -1428,6 +1520,20 @@ VkImage vklCreateDeviceLocalImageWithBackingMemory(VkPhysicalDevice physical_dev
 		.setUsage(static_cast<vk::ImageUsageFlags>(usage_flags))
 		.setSamples(vk::SampleCountFlagBits::e1)
 		.setSharingMode(vk::SharingMode::eExclusive);
+
+#ifdef USE_VMA
+	if (mVmaAllocator) {
+		VmaAllocationCreateInfo vmaImageCreateInfo = {};
+		vmaImageCreateInfo.usage = VMA_MEMORY_USAGE_UNKNOWN;
+		vmaImageCreateInfo.requiredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+		VkImage imageFromVma;
+		VmaAllocation vmaAllocation;
+		vmaCreateImage(mVmaAllocator, &static_cast<const VkImageCreateInfo&>(createInfo), &vmaImageCreateInfo, &imageFromVma, &vmaAllocation, nullptr);
+		mImagesWithBackingMemory[imageFromVma] = std::move(vmaAllocation);
+		return imageFromVma;
+	}
+#endif
+
 	auto image = vk::Device{ device }.createImage(createInfo);
 
 	auto memoryRequirements = vk::Device{ device }.getImageMemoryRequirements(image);
@@ -1512,15 +1618,24 @@ void vklDestroyDeviceLocalImageAndItsBackingMemory(VkImage image)
 		VKL_EXIT_WITH_ERROR("Invalid image handle passed to vklDestroyImageAndItsBackingMemory(...)");
 	}
 
+	bool resourceDestroyed = false;
 	auto search = mImagesWithBackingMemory.find(image);
 	if (mImagesWithBackingMemory.end() != search) {
+#ifdef USE_VMA
+		if (std::holds_alternative<VmaAllocation>(search->second)) {
+			vmaDestroyImage(mVmaAllocator, image, std::get<VmaAllocation>(search->second));
+			resourceDestroyed = true;
+		}
+#endif
 		mImagesWithBackingMemory.erase(search);
 	}
 	else {
 		VKL_WARNING("VkDeviceMemory for the given VkImage not found. Are you sure that you have created this buffer with vklCreateDeviceLocalImageWithBackingMemory(...)? Are you sure that you haven't already destroyed this VkImage?");
 	}
 
-	mDevice.destroy(vk::Image{ image });
+	if (!resourceDestroyed) {
+		mDevice.destroy(vk::Image{ image });
+	}
 }
 #pragma endregion
 

--- a/VulkanLaunchpad.h
+++ b/VulkanLaunchpad.h
@@ -16,6 +16,11 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/glm.hpp>
 
+#if __has_include(<vma/vk_mem_alloc.h>)
+#define VKL_HAS_VMA
+#include <vma/vk_mem_alloc.h>
+#endif
+
 // Returns a string describing the given VkResult value
 extern const char *to_string(VkResult result);
 
@@ -204,10 +209,20 @@ extern const char *vklRequiredInstanceExtensions[];
 const char **vklGetRequiredInstanceExtensions(uint32_t *out_count);
 
 /*!
- * Initializes the framework
+ *  Initializes the framework
  */
 bool vklInitFramework(VkInstance vk_instance, VkSurfaceKHR vk_surface, VkPhysicalDevice vk_physical_device,
                       VkDevice vk_device, VkQueue vk_queue, const VklSwapchainConfig &swapchain_config);
+
+#ifdef VKL_HAS_VMA
+/*!
+ *  Initializes the framework.
+ *  This overload additionally takes a VmaAllocator handle
+ */
+bool vklInitFramework(VkInstance vk_instance, VkSurfaceKHR vk_surface, VkPhysicalDevice vk_physical_device,
+                      VkDevice vk_device, VkQueue vk_queue, const VklSwapchainConfig &swapchain_config,
+                      VmaAllocator vma_allocator);
+#endif 
 
 /*!
  * Returns true if the framework has been properly initialized, false otherwise.


### PR DESCRIPTION
Yo, I've added support for VMA, because I'd like to tweet to Chris Glover that he now gets what he wants in Vulkan Launchpad. ;) 

I'm hereby asking you for a quick review of the code.
Usage of VMA can be switched on/off by defining/undefining the `USE_VMA` macro.

Known issues:
- Some image does not get destroyed properly... gotta look into that later
- One cannot switch on VMA if Vulkan Launchpad is built as a library.

Regarding the latter point: There is currently a `#define USE_VMA` at the top of `VulkanLaunchpad.cpp`. But that's uncool.      
What would be cool, would be to add it before including Vulkan Launchpad, i.e., like so:            
```cpp
#define USE_VMA 
#include <VulkanLaunchpad.h>
```
buuut that doesn't work right now with Vulkan Launchpad Starter (I think) because Vulkan Launchpad is built as a library. Any suggestions about that? 

I think there is that "`INCLUDE`"-library type in CMake, which does not really build it as a library but merely includes all the source files. Would that be an option?